### PR TITLE
remove the call to removeChild when reordering

### DIFF
--- a/patch-op.js
+++ b/patch-op.js
@@ -127,7 +127,6 @@ function reorderChildren(domNode, bIndex) {
         var move = bIndex[i]
         if (move !== undefined) {
             var node = children[move]
-            domNode.removeChild(node)
             domNode.insertBefore(node, childNodes[i])
         }
     }


### PR DESCRIPTION
the call to removeChild when reordering is unnecessary.  i found that in Chrome and Safari, there is a blur event that can be avoided if the call to removeChild is removed.

calling insertBefore seems to be sufficient and removing this call does not introduce any new errors that i noticed.
