### PR TITLE
avoid unnecessary reordering

### DIFF
--- a/patch-op.js
+++ b/patch-op.js
@@ -125,7 +125,7 @@ function reorderChildren(domNode, bIndex) {
 
     for (i = 0; i < len; i++) {
         var move = bIndex[i]
-        if (move !== undefined) {
+        if (move !== undefined && move !== i) {
             var node = children[move]
             domNode.removeChild(node)
             domNode.insertBefore(node, childNodes[i])


### PR DESCRIPTION
this is a safeguard to ensure that items with the same index are not touched as part of reordering.

ideally, `reorder` in vdom/diff should be patched to stop producing these unnecessary patches and tests should be added.

this is the simplest option but is probably a reasonable safeguard to keep even if vdom/diff is fixed.
