### PR TITLE
Fix for removal of data attributes durring patch operations

### DIFF
--- a/apply-properties.js
+++ b/apply-properties.js
@@ -77,7 +77,11 @@ function patchObject(node, props, previous, propName, propValue) {
 
     for (var k in propValue) {
         var value = propValue[k]
-        node[propName][k] = (value === undefined) ? replacer : value
+        if (propName === 'dataset' && value === undefined) {
+            delete node[propName][k]
+        } else {
+            node[propName][k] = (value === undefined) ? replacer : value
+        }
     }
 }
 


### PR DESCRIPTION
After removing a data attribute a patch operation will set the value to the string 'undefined'.

The original dom looks like this:

``` html
<div data-collection="<ESCAPED JSON DATA>"></div>
```

The new dom like this:

``` html
<div></div>
```

And the patch contains this:

``` javascript
{
  patch: {
    dataset: {
      collection: undefined
    }
  }
}
```

Which results in this:

``` html
<div data-collection="undefined"></div>
```

It has to do with this:

https://github.com/Matt-Esch/vdom/blob/master/apply-properties.js#L80

``` javascript
    for (var k in propValue) {
        var value = propValue[k]
        node[propName][k] = (value === undefined) ? replacer : value
    }
```

`replacer` is undefined, as is value.  So you still end up setting the property to `undefined`.  You get the same result by just running this in your console:

``` javascript
document.body.dataset.foo = undefined;  // Body now has: <body data-foo="undefined">
```

This is one possible fix for this issue.  If you see any problems with calling out this directly like this let me know and I will update.
