### PR TITLE
Avoid dependency on global document.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ var leftNode = new VNode("div")
 var rightNode = new VNode("text")
 
 // Render the left node to a DOM node
-var rootNode = createElement(leftNode)
+var rootNode = createElement(leftNode, { document: document })
 document.body.appendChild(rootNode)
 
 // Update the DOM with the results of a diff

--- a/create-element.js
+++ b/create-element.js
@@ -1,5 +1,3 @@
-var document = require("global/document")
-
 var applyProperties = require("./apply-properties")
 
 var isVNode = require("vtree/is-vnode")
@@ -10,7 +8,7 @@ var handleThunk = require("vtree/handle-thunk")
 module.exports = createElement
 
 function createElement(vnode, opts) {
-    var doc = opts ? opts.document || document : document
+    var doc = opts.document
     var warn = opts ? opts.warn : null
 
     vnode = handleThunk(vnode).a

--- a/package.json
+++ b/package.json
@@ -17,14 +17,14 @@
     "email": "matt@mattesch.info"
   },
   "dependencies": {
-    "global": "4.2.1",
     "is-object": "0.1.2",
     "vtree": "0.0.21",
     "x-is-array": "0.1.0"
   },
   "devDependencies": {
     "tape": "^2.13.1",
-    "virtual-dom": "0.0.10"
+    "virtual-dom": "0.0.10",
+    "global": "4.2.1"
   },
   "licenses": [
     {

--- a/patch.js
+++ b/patch.js
@@ -1,4 +1,3 @@
-var document = require("global/document")
 var isArray = require("x-is-array")
 
 var domIndex = require("./dom-index")
@@ -20,10 +19,8 @@ function patchRecursive(rootNode, patches, renderOptions) {
     var ownerDocument = rootNode.ownerDocument
 
     if (!renderOptions) {
-        renderOptions = { patch: patchRecursive }
-        if (ownerDocument !== document) {
-            renderOptions.document = ownerDocument
-        }
+        renderOptions = { patch: patchRecursive,
+                          document: ownerDocument }
     }
 
     for (var i = 0; i < indices.length; i++) {

--- a/test/dom-index.js
+++ b/test/dom-index.js
@@ -2,6 +2,7 @@ var test = require("tape")
 var VNode = require("vtree/vnode")
 var VText = require("vtree/vtext")
 var diff = require("vtree/diff")
+var document = require("global/document")
 
 var createElement = require("../create-element")
 var patch = require("../patch")
@@ -25,7 +26,7 @@ test("indexing over thunk root", function (assert) {
         }
     }
 
-    var root = createElement(leftThunk)
+    var root = createElement(leftThunk, { document: document })
     var patches = diff(leftThunk, rightThunk)
     var newRoot = patch(root, patches)
 
@@ -68,7 +69,7 @@ test("indexing over thunk child", function (assert) {
         new VText("test")
     ])
 
-    var root = createElement(leftNode)
+    var root = createElement(leftNode, { document: document })
     var patches = diff(leftNode, rightNode)
     patch(root, patches)
     assert.equal(root.childNodes[2].childNodes[0].data, "Right")


### PR DESCRIPTION
I would like to use this library in the context where there is no single global or document (It is a browser code that has access to every document loaded, but there is not a single one that we could pick) there for it isn't possible to provide something like `require("global/document")`.

As far as I see `createElement` without document, is just for a convenience of the API, if it's really crucial maybe some other package could wrap this `createElement` to do that.
